### PR TITLE
CI: Run Renovate less frequently

### DIFF
--- a/.github/workflows/trigger-renovate.yaml
+++ b/.github/workflows/trigger-renovate.yaml
@@ -13,7 +13,7 @@ on:
         default: debug
         required: false
   schedule:
-    - cron: "10 * * * 5"
+    - cron: "10 * 1 * *"
   push:
     branches: ["main"]
     paths:


### PR DESCRIPTION
There is no need to have weekly updates. Better to bundle it into a single day of the month.