### PR TITLE
Renovate: Remove pin for github actions on client repos

### DIFF
--- a/renovate/configs/golang.json5
+++ b/renovate/configs/golang.json5
@@ -12,8 +12,7 @@
     "github>heathcliff26/ci//renovate/customManagers.json5",
     "github>heathcliff26/ci//renovate/group-gomod.json5",
     "github>heathcliff26/ci//renovate/labels.json5",
-    "github>heathcliff26/ci//renovate/semanticCommits.json5",
-    "helpers:pinGitHubActionDigests"
+    "github>heathcliff26/ci//renovate/semanticCommits.json5"
   ],
   "assigneesFromCodeOwners": true,
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",

--- a/renovate/configs/rust.json5
+++ b/renovate/configs/rust.json5
@@ -11,8 +11,7 @@
     "github>heathcliff26/ci//renovate/customManagers.json5",
     "github>heathcliff26/ci//renovate/group-cargo.json5",
     "github>heathcliff26/ci//renovate/labels.json5",
-    "github>heathcliff26/ci//renovate/semanticCommits.json5",
-    "helpers:pinGitHubActionDigests"
+    "github>heathcliff26/ci//renovate/semanticCommits.json5"
   ],
   "assigneesFromCodeOwners": true,
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",


### PR DESCRIPTION
Renovate started pinning actions on client repos. This is undesired, it should not pin the main branch of this repo.